### PR TITLE
chore(ci): Temporarily disable armv7 cross compilation 

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -18,10 +18,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-          - bin: swap
-            target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-latest
-            archive_ext: tar
+        # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
+        #- bin: swap
+        #   target: armv7-unknown-linux-gnueabihf
+        #   os: ubuntu-latest
+        #   archive_ext: tar
           - bin: swap
             target: x86_64-apple-darwin
             os: macos-12
@@ -38,10 +39,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-          - bin: asb
-            target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-latest
-            archive_ext: tar
+        # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
+        #- bin: asb
+        #   target: armv7-unknown-linux-gnueabihf
+        #   os: ubuntu-latest
+        #   archive_ext: tar
           - bin: asb
             target: x86_64-apple-darwin
             os: macos-12

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -18,11 +18,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-        # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
-        #- bin: swap
-        #   target: armv7-unknown-linux-gnueabihf
-        #   os: ubuntu-latest
-        #   archive_ext: tar
+          # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
+          #- bin: swap
+          #   target: armv7-unknown-linux-gnueabihf
+          #   os: ubuntu-latest
+          #   archive_ext: tar
           - bin: swap
             target: x86_64-apple-darwin
             os: macos-12
@@ -39,11 +39,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-        # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
-        #- bin: asb
-        #   target: armv7-unknown-linux-gnueabihf
-        #   os: ubuntu-latest
-        #   archive_ext: tar
+          # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
+          #- bin: asb
+          #   target: armv7-unknown-linux-gnueabihf
+          #   os: ubuntu-latest
+          #   archive_ext: tar
           - bin: asb
             target: x86_64-apple-darwin
             os: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Check formatting
         uses: dprint/check@v2.2
         with:
@@ -64,7 +64,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Build swap
         run: cargo build --bin swap
 
@@ -91,7 +91,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Install sqlx-cli
         run: cargo install --locked --version 0.6.3 sqlx-cli
 
@@ -106,8 +106,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-latest
+          #- target: armv7-unknown-linux-gnueabihf
+          #   os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-12
           - target: aarch64-apple-darwin
@@ -139,7 +139,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Build binary
         if: matrix.target != 'armv7-unknown-linux-gnueabihf'
         run: cargo build -p swap --target ${{ matrix.target }}
@@ -196,7 +196,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Checkout sources
         uses: actions/checkout@v4.1.7
 
@@ -254,7 +254,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Run test ${{ matrix.test_name }}
         run: cargo test --package swap --all-features --test ${{ matrix.test_name }} -- --nocapture
 
@@ -278,7 +278,7 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Run RPC server tests
         run: cargo test --package swap --all-features --test rpc -- --nocapture
 
@@ -304,6 +304,6 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
-            
+
       - name: Run cargo check on stable rust
         run: cargo check --all-targets


### PR DESCRIPTION
Cross compilation is currently broken due to the missing system dependencies (libwebkit). This PR (temporarily) disabled that target.