### PR TITLE
refactor(cli): Refactor RPC server and fix tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3594,15 +3594,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata 0.1.10",
-]
 
 [[package]]
 name = "matchers"
@@ -3743,7 +3734,7 @@ dependencies = [
  "testcontainers",
  "tokio",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3778,7 +3769,7 @@ dependencies = [
  "rand 0.7.3",
  "testcontainers",
  "tokio",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6490,7 +6481,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-futures",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
  "typeshare",
  "url",
  "uuid",
@@ -7303,7 +7294,7 @@ dependencies = [
  "crossbeam-channel",
  "thiserror",
  "time 0.3.36",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7341,17 +7332,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -7373,29 +7353,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "sharded-slab",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
-]
-
-[[package]]
-name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers 0.1.0",
+ "chrono",
+ "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex",
@@ -7407,7 +7370,7 @@ dependencies = [
  "time 0.3.36",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 

--- a/monero-harness/Cargo.toml
+++ b/monero-harness/Cargo.toml
@@ -13,4 +13,4 @@ rand = "0.7"
 testcontainers = "0.15"
 tokio = { version = "1", default-features = false, features = [ "rt-multi-thread", "time", "macros" ] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.2", default-features = false, features = [ "fmt", "ansi", "env-filter", "tracing-log" ] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [ "fmt", "ansi", "env-filter", "tracing-log" ] }

--- a/monero-wallet/Cargo.toml
+++ b/monero-wallet/Cargo.toml
@@ -16,4 +16,4 @@ monero-harness = { path = "../monero-harness" }
 rand = "0.7"
 testcontainers = "0.15"
 tokio = { version = "1", features = [ "rt-multi-thread", "time", "macros", "sync", "process", "fs" ] }
-tracing-subscriber = { version = "0.2", default-features = false, features = [ "fmt", "ansi", "env-filter", "chrono", "tracing-log" ] }
+tracing-subscriber = { version = "0.3", default-features = false, features = [ "fmt", "ansi", "env-filter", "chrono", "tracing-log" ] }

--- a/swap/sqlx-data.json
+++ b/swap/sqlx-data.json
@@ -80,30 +80,6 @@
     },
     "query": "\n        insert into peers (\n            swap_id,\n            peer_id\n            ) values (?, ?);\n        "
   },
-  "3f2bfdd2d134586ccad22171cd85a465800fc5c4fdaf191d206974e530240c87": {
-    "describe": {
-      "columns": [
-        {
-          "name": "swap_id",
-          "ordinal": 0,
-          "type_info": "Text"
-        },
-        {
-          "name": "state",
-          "ordinal": 1,
-          "type_info": "Text"
-        }
-      ],
-      "nullable": [
-        false,
-        false
-      ],
-      "parameters": {
-        "Right": 0
-      }
-    },
-    "query": "\n                SELECT swap_id, state\n                FROM swap_states\n                "
-  },
   "50a5764546f69c118fa0b64120da50f51073d36257d49768de99ff863e3511e0": {
     "describe": {
       "columns": [],

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -507,7 +507,6 @@ pub mod api_test {
             Self {
                 tor_socks5_port: 9050,
                 namespace: XmrBtcNamespace::from_is_testnet(is_testnet),
-                server_address: None,
                 env_config,
                 seed: Some(seed),
                 debug,

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -304,9 +304,9 @@ impl Request for SuspendCurrentSwapArgs {
     }
 }
 
-pub struct GetCurrentSwap;
+pub struct GetCurrentSwapArgs;
 
-impl Request for GetCurrentSwap {
+impl Request for GetCurrentSwapArgs {
     type Response = serde_json::Value;
 
     async fn request(self, ctx: Arc<Context>) -> Result<Self::Response> {
@@ -860,13 +860,6 @@ pub async fn get_history(context: Arc<Context>) -> Result<GetHistoryResponse> {
     Ok(GetHistoryResponse { swaps: vec })
 }
 
-#[tracing::instrument(fields(method = "get_raw_states"), skip(context))]
-pub async fn get_raw_states(context: Arc<Context>) -> Result<serde_json::Value> {
-    let raw_history = context.db.raw_all().await?;
-
-    Ok(json!({ "raw_states": raw_history }))
-}
-
 #[tracing::instrument(fields(method = "get_config"), skip(context))]
 pub async fn get_config(context: Arc<Context>) -> Result<serde_json::Value> {
     let data_dir_display = context.config.data_dir.display();
@@ -1164,7 +1157,7 @@ where
                         min_deposit_until_swap_will_start,
                         max_deposit_until_maximum_amount_is_reached,
                         min_bitcoin_lock_tx_fee,
-                        quote: bid_quote.clone(),
+                        quote: bid_quote,
                     },
                 );
             }

--- a/swap/src/protocol.rs
+++ b/swap/src/protocol.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sigma_fun::ext::dl_secp256k1_ed25519_eq::{CrossCurveDLEQ, CrossCurveDLEQProof};
 use sigma_fun::HashTranscript;
-use std::collections::HashMap;
 use std::convert::TryInto;
 use uuid::Uuid;
 
@@ -145,7 +144,6 @@ pub trait Database {
     async fn get_state(&self, swap_id: Uuid) -> Result<State>;
     async fn get_states(&self, swap_id: Uuid) -> Result<Vec<State>>;
     async fn all(&self) -> Result<Vec<(Uuid, State)>>;
-    async fn raw_all(&self) -> Result<HashMap<Uuid, Vec<serde_json::Value>>>;
     async fn insert_buffered_transfer_proof(
         &self,
         swap_id: Uuid,

--- a/swap/src/rpc/methods.rs
+++ b/swap/src/rpc/methods.rs
@@ -1,18 +1,13 @@
 use crate::bitcoin::bitcoin_address;
 use crate::cli::api::request::{
-    get_current_swap, get_history, get_raw_states, suspend_current_swap, BalanceArgs, BuyXmrArgs,
-    CancelAndRefundArgs, GetSwapInfoArgs, ListSellersArgs, MoneroRecoveryArgs, Request,
-    ResumeSwapArgs, WithdrawBtcArgs,
+    BalanceArgs, BuyXmrArgs, CancelAndRefundArgs, GetCurrentSwapArgs, GetHistoryArgs,
+    GetSwapInfoArgs, ListSellersArgs, MoneroRecoveryArgs, Request, ResumeSwapArgs,
+    SuspendCurrentSwapArgs, WithdrawBtcArgs,
 };
 use crate::cli::api::Context;
 use crate::monero::monero_address;
-use crate::{bitcoin, monero};
 use anyhow::Result;
 use jsonrpsee::server::RpcModule;
-use libp2p::core::Multiaddr;
-use std::collections::HashMap;
-use std::str::FromStr;
-use uuid::Uuid;
 
 trait ConvertToJsonRpseeError<T> {
     fn to_jsonrpsee_result(self) -> Result<T, jsonrpsee_core::Error>;
@@ -28,209 +23,92 @@ pub fn register_modules(outer_context: Context) -> Result<RpcModule<Context>> {
     let mut module = RpcModule::new(outer_context);
 
     module.register_async_method("suspend_current_swap", |_, context| async move {
-        suspend_current_swap(context).await.to_jsonrpsee_result()
+        SuspendCurrentSwapArgs {}
+            .request(context)
+            .await
+            .to_jsonrpsee_result()
     })?;
 
     module.register_async_method("get_swap_info", |params_raw, context| async move {
-        let params: HashMap<String, serde_json::Value> = params_raw.parse()?;
+        let params: GetSwapInfoArgs = params_raw.parse()?;
 
-        let swap_id = params
-            .get("swap_id")
-            .ok_or_else(|| jsonrpsee_core::Error::Custom("Does not contain swap_id".to_string()))?;
-
-        let swap_id = as_uuid(swap_id)
-            .ok_or_else(|| jsonrpsee_core::Error::Custom("Could not parse swap_id".to_string()))?;
-
-        GetSwapInfoArgs { swap_id }
-            .request(context)
-            .await
-            .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method("get_bitcoin_balance", |params_raw, context| async move {
-        let params: HashMap<String, serde_json::Value> = params_raw.parse()?;
+        let params: BalanceArgs = params_raw.parse()?;
 
-        let force_refresh = params
-            .get("force_refresh")
-            .ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Does not contain force_refresh".to_string())
-            })?
-            .as_bool()
-            .ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("force_refesh is not a boolean".to_string())
-            })?;
-
-        BalanceArgs { force_refresh }
-            .request(context)
-            .await
-            .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method("get_history", |_, context| async move {
-        get_history(context).await.to_jsonrpsee_result()
-    })?;
-
-    module.register_async_method("get_raw_states", |_, context| async move {
-        get_raw_states(context).await.to_jsonrpsee_result()
+        GetHistoryArgs {}
+            .request(context)
+            .await
+            .to_jsonrpsee_result()
     })?;
 
     module.register_async_method("resume_swap", |params_raw, context| async move {
-        let params: HashMap<String, serde_json::Value> = params_raw.parse()?;
+        let params: ResumeSwapArgs = params_raw.parse()?;
 
-        let swap_id = params
-            .get("swap_id")
-            .ok_or_else(|| jsonrpsee_core::Error::Custom("Does not contain swap_id".to_string()))?;
-
-        let swap_id = as_uuid(swap_id)
-            .ok_or_else(|| jsonrpsee_core::Error::Custom("Could not parse swap_id".to_string()))?;
-
-        ResumeSwapArgs { swap_id }
-            .request(context)
-            .await
-            .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method("cancel_refund_swap", |params_raw, context| async move {
-        let params: HashMap<String, serde_json::Value> = params_raw.parse()?;
+        let params: CancelAndRefundArgs = params_raw.parse()?;
 
-        let swap_id = params
-            .get("swap_id")
-            .ok_or_else(|| jsonrpsee_core::Error::Custom("Does not contain swap_id".to_string()))?;
-
-        let swap_id = as_uuid(swap_id)
-            .ok_or_else(|| jsonrpsee_core::Error::Custom("Could not parse swap_id".to_string()))?;
-
-        CancelAndRefundArgs { swap_id }
-            .request(context)
-            .await
-            .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method(
         "get_monero_recovery_info",
         |params_raw, context| async move {
-            let params: HashMap<String, serde_json::Value> = params_raw.parse()?;
+            let params: MoneroRecoveryArgs = params_raw.parse()?;
 
-            let swap_id = params.get("swap_id").ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Does not contain swap_id".to_string())
-            })?;
-
-            let swap_id = as_uuid(swap_id).ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Could not parse swap_id".to_string())
-            })?;
-
-            MoneroRecoveryArgs { swap_id }
-                .request(context)
-                .await
-                .to_jsonrpsee_result()
+            params.request(context).await.to_jsonrpsee_result()
         },
     )?;
 
     module.register_async_method("withdraw_btc", |params_raw, context| async move {
-        let params: HashMap<String, String> = params_raw.parse()?;
+        let mut params: WithdrawBtcArgs = params_raw.parse()?;
 
-        let amount = if let Some(amount_str) = params.get("amount") {
-            Some(
-                ::bitcoin::Amount::from_str_in(amount_str, ::bitcoin::Denomination::Bitcoin)
-                    .map_err(|_| {
-                        jsonrpsee_core::Error::Custom("Unable to parse amount".to_string())
-                    })?,
-            )
-        } else {
-            None
-        };
+        params.address =
+            bitcoin_address::validate(params.address, context.config.env_config.bitcoin_network)
+                .to_jsonrpsee_result()?;
 
-        let withdraw_address =
-            bitcoin::Address::from_str(params.get("address").ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Does not contain address".to_string())
-            })?)
-            .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))?;
-        let withdraw_address =
-            bitcoin_address::validate(withdraw_address, context.config.env_config.bitcoin_network)?;
-
-        WithdrawBtcArgs {
-            amount,
-            address: withdraw_address,
-        }
-        .request(context)
-        .await
-        .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method("buy_xmr", |params_raw, context| async move {
-        let params: HashMap<String, String> = params_raw.parse()?;
+        let mut params: BuyXmrArgs = params_raw.parse()?;
 
-        let bitcoin_change_address =
-            bitcoin::Address::from_str(params.get("bitcoin_change_address").ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Does not contain bitcoin_change_address".to_string())
-            })?)
-            .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))?;
-
-        let bitcoin_change_address = bitcoin_address::validate(
-            bitcoin_change_address,
+        params.bitcoin_change_address = bitcoin_address::validate(
+            params.bitcoin_change_address,
             context.config.env_config.bitcoin_network,
-        )?;
+        )
+        .to_jsonrpsee_result()?;
 
-        let monero_receive_address =
-            monero::Address::from_str(params.get("monero_receive_address").ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Does not contain monero_receiveaddress".to_string())
-            })?)
-            .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))?;
-
-        let monero_receive_address = monero_address::validate(
-            monero_receive_address,
+        params.monero_receive_address = monero_address::validate(
+            params.monero_receive_address,
             context.config.env_config.monero_network,
-        )?;
+        )
+        .to_jsonrpsee_result()?;
 
-        let seller =
-            Multiaddr::from_str(params.get("seller").ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Does not contain seller".to_string())
-            })?)
-            .map_err(|err| jsonrpsee_core::Error::Custom(err.to_string()))?;
-
-        BuyXmrArgs {
-            seller,
-            bitcoin_change_address,
-            monero_receive_address,
-        }
-        .request(context)
-        .await
-        .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method("list_sellers", |params_raw, context| async move {
-        let params: HashMap<String, serde_json::Value> = params_raw.parse()?;
+        let params: ListSellersArgs = params_raw.parse()?;
 
-        let rendezvous_point = params.get("rendezvous_point").ok_or_else(|| {
-            jsonrpsee_core::Error::Custom("Does not contain rendezvous_point".to_string())
-        })?;
-
-        let rendezvous_point = rendezvous_point
-            .as_str()
-            .and_then(|addr_str| Multiaddr::from_str(addr_str).ok())
-            .ok_or_else(|| {
-                jsonrpsee_core::Error::Custom("Could not parse valid multiaddr".to_string())
-            })?;
-
-        ListSellersArgs {
-            rendezvous_point: rendezvous_point.clone(),
-        }
-        .request(context)
-        .await
-        .to_jsonrpsee_result()
+        params.request(context).await.to_jsonrpsee_result()
     })?;
 
     module.register_async_method("get_current_swap", |_, context| async move {
-        get_current_swap(context).await.to_jsonrpsee_result()
+        GetCurrentSwapArgs {}
+            .request(context)
+            .await
+            .to_jsonrpsee_result()
     })?;
 
     Ok(module)
-}
-
-fn as_uuid(json_value: &serde_json::Value) -> Option<Uuid> {
-    if let Some(uuid_str) = json_value.as_str() {
-        Uuid::parse_str(uuid_str).ok()
-    } else {
-        None
-    }
 }


### PR DESCRIPTION
- Use the Request trait introduced in https://github.com/UnstoppableSwap/xmr-btc-swap/pull/10 for the RPC server
- Delegate deserialization of RPC server method parameters to serde by using structs like BuyXmrArgs
- Remove `get_raw_states` RPC server method because it's not used
- Fix RPC server tests including removing test for the "log reference id" feature which was removed as part of https://github.com/UnstoppableSwap/xmr-btc-swap/pull/10
- Rename GetCurrentSwap struct to GetCurrentSwapArgs