### PR TITLE
feat(swap): tauri feature flag

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -18,11 +18,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-          # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
-          #- bin: swap
-          #   target: armv7-unknown-linux-gnueabihf
-          #   os: ubuntu-latest
-          #   archive_ext: tar
+          - bin: swap
+            target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            archive_ext: tar
           - bin: swap
             target: x86_64-apple-darwin
             os: macos-12
@@ -39,11 +38,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             archive_ext: tar
-          # This has been temporarily disabled. Cross compilation is currently broken due to the missing system dependencies (libwebkit)
-          #- bin: asb
-          #   target: armv7-unknown-linux-gnueabihf
-          #   os: ubuntu-latest
-          #   archive_ext: tar
+          - bin: asb
+            target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
+            archive_ext: tar
           - bin: asb
             target: x86_64-apple-darwin
             os: macos-12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,8 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          #- target: armv7-unknown-linux-gnueabihf
-          #   os: ubuntu-latest
+          - target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-latest
           - target: x86_64-apple-darwin
             os: macos-12
           - target: aarch64-apple-darwin

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,5 +19,5 @@ anyhow = "1"
 once_cell = "1"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-swap = { path = "../swap" }
+swap = { path = "../swap", features = [ "tauri" ] }
 tauri = { version = "2.0.0-rc.1", features = [ "config-json5" ] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use swap::cli::{
             BalanceArgs, BuyXmrArgs, GetHistoryArgs, GetSwapInfosAllArgs, ResumeSwapArgs,
             SuspendCurrentSwapArgs, WithdrawBtcArgs,
         },
+        tauri_bindings::TauriHandle,
         Context, ContextBuilder,
     },
     command::{Bitcoin, Monero},
@@ -86,7 +87,7 @@ tauri_command!(suspend_current_swap, SuspendCurrentSwapArgs, no_args);
 tauri_command!(get_swap_infos_all, GetSwapInfosAllArgs, no_args);
 tauri_command!(get_history, GetHistoryArgs, no_args);
 
-fn setup<'a>(app: &'a mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
+fn setup(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
     tauri::async_runtime::block_on(async {
         let context = ContextBuilder::new(true)
             .with_bitcoin(Bitcoin {
@@ -98,7 +99,7 @@ fn setup<'a>(app: &'a mut tauri::App) -> Result<(), Box<dyn std::error::Error>> 
             })
             .with_json(true)
             .with_debug(true)
-            .with_tauri(app.app_handle().to_owned())
+            .with_tauri(TauriHandle::new(app.app_handle().to_owned()))
             .build()
             .await
             .expect("failed to create context");

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -8,6 +8,9 @@ description = "XMR/BTC trustless atomic swaps."
 [lib]
 name = "swap"
 
+[features]
+tauri = [ "dep:tauri" ]
+
 [dependencies]
 anyhow = "1"
 async-compression = { version = "0.3", features = [ "bzip2", "tokio" ] }
@@ -86,7 +89,7 @@ sqlx = { version = "0.6.3", features = [
 ] }
 structopt = "0.3"
 strum = { version = "0.26", features = [ "derive" ] }
-tauri = { version = "2.0.0-rc.1", features = [ "config-json5" ] }
+tauri = { version = "2.0.0-rc.1", features = [ "config-json5" ], optional = true }
 thiserror = "1"
 time = "0.3"
 tokio = { version = "1", features = [

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -1,5 +1,6 @@
 pub mod request;
 pub mod tauri_bindings;
+
 use crate::cli::command::{Bitcoin, Monero, Tor};
 use crate::database::open_db;
 use crate::env::{Config as EnvConfig, GetConfig, Mainnet, Testnet};
@@ -14,7 +15,6 @@ use std::fmt;
 use std::future::Future;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex as SyncMutex, Once};
-use tauri::AppHandle;
 use tauri_bindings::TauriHandle;
 use tokio::sync::{broadcast, broadcast::Sender, Mutex as TokioMutex, RwLock};
 use tokio::task::JoinHandle;
@@ -193,7 +193,7 @@ pub struct ContextBuilder {
     is_testnet: bool,
     debug: bool,
     json: bool,
-    tauri_handle: Option<AppHandle>,
+    tauri_handle: Option<TauriHandle>,
 }
 
 impl ContextBuilder {
@@ -246,7 +246,7 @@ impl ContextBuilder {
     }
 
     /// Attach a handle to Tauri to the Context for emitting events etc.
-    pub fn with_tauri(mut self, tauri: impl Into<Option<AppHandle>>) -> Self {
+    pub fn with_tauri(mut self, tauri: impl Into<Option<TauriHandle>>) -> Self {
         self.tauri_handle = tauri.into();
         self
     }
@@ -330,7 +330,7 @@ impl ContextBuilder {
             },
             swap_lock: Arc::new(SwapLock::new()),
             tasks: Arc::new(PendingTaskList::default()),
-            tauri_handle: self.tauri_handle.map(TauriHandle::new),
+            tauri_handle: self.tauri_handle,
         };
 
         Ok(context)
@@ -338,8 +338,8 @@ impl ContextBuilder {
 }
 
 impl Context {
-    pub fn with_tauri_handle(mut self, tauri_handle: AppHandle) -> Self {
-        self.tauri_handle = Some(TauriHandle::new(tauri_handle));
+    pub fn with_tauri_handle(mut self, tauri_handle: impl Into<Option<TauriHandle>>) -> Self {
+        self.tauri_handle = tauri_handle.into();
 
         self
     }

--- a/swap/src/cli/api/tauri_bindings.rs
+++ b/swap/src/cli/api/tauri_bindings.rs
@@ -4,8 +4,6 @@
 use anyhow::Result;
 use bitcoin::Txid;
 use serde::Serialize;
-use std::sync::Arc;
-use tauri::{AppHandle, Emitter};
 use typeshare::typeshare;
 use uuid::Uuid;
 
@@ -14,15 +12,27 @@ use crate::{monero, network::quote::BidQuote};
 static SWAP_PROGRESS_EVENT_NAME: &str = "swap-progress-update";
 
 #[derive(Debug, Clone)]
-pub struct TauriHandle(Arc<AppHandle>);
+pub struct TauriHandle(
+    #[cfg(feature = "tauri")]
+    #[cfg_attr(feature = "tauri", allow(unused))]
+    std::sync::Arc<tauri::AppHandle>,
+);
 
 impl TauriHandle {
-    pub fn new(tauri_handle: AppHandle) -> Self {
-        Self(Arc::new(tauri_handle))
+    #[cfg(feature = "tauri")]
+    pub fn new(tauri_handle: tauri::AppHandle) -> Self {
+        Self(
+            #[cfg(feature = "tauri")]
+            std::sync::Arc::new(tauri_handle),
+        )
     }
 
+    #[allow(unused_variables)]
     pub fn emit_tauri_event<S: Serialize + Clone>(&self, event: &str, payload: S) -> Result<()> {
-        self.0.emit(event, payload).map_err(|e| e.into())
+        #[cfg(tauri)]
+        self.0.emit(event, payload).map_err(|e| e.into())?;
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Introducing a feature flag in the `swap` crate that conditionally enables the `tauri` depencendy. This allows compiling the `swap` crate without the heavy `tauri` dependency. This also enables us to build arm binaries in the CI again.

This closes #32 and #34