### PR TITLE
ci: create gui preview release on push to master

### DIFF
--- a/.github/workflows/build-gui-preview-release-binaries.yml
+++ b/.github/workflows/build-gui-preview-release-binaries.yml
@@ -1,0 +1,62 @@
+# This file is used to build the preview release binaries for the Tauri GUI
+name: "publish gui"
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  publish-tauri:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: "macos-latest" # for Arm based macs (M1 and above).
+            args: "--target aarch64-apple-darwin"
+          - platform: "macos-latest" # for Intel based macs.
+            args: "--target x86_64-apple-darwin"
+          - platform: "ubuntu-22.04" # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ""
+          - platform: "windows-latest"
+            args: ""
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: install Rust stable
+        uses: dtolnay/rust-toolchain@1.79
+        with:
+          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: install dependencies (ubuntu only)
+        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+
+      - name: install frontend dependencies
+        working-directory: src-gui
+        run: yarn install
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: gui-preview
+          releaseName: "GUI Preview Release"
+          releaseBody: "This is a preview release of the GUI. This is not a stable release. Please only use this release for testing purposes."
+          releaseDraft: true
+          prerelease: true
+          includeDebug: true
+          projectPath: src-tauri
+          args: ${{ matrix.args }}

--- a/src-gui/package.json
+++ b/src-gui/package.json
@@ -8,7 +8,7 @@
     "gen-bindings": "typeshare --lang=typescript --output-file ./src/models/tauriModel.ts ../swap/src && dprint fmt ./src/models/tauriModel.ts",
     "dev": "vite",
     "prebuild": "yarn run gen-bindings",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -8,6 +8,10 @@
     "beforeDevCommand": {
       "cwd": "../src-gui",
       "script": "yarn run dev"
+    },
+    "beforeBuildCommand": {
+      "cwd": "../src-gui",
+      "script": "yarn run build"
     }
   },
   "app": {
@@ -19,7 +23,9 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' http://localhost:1234 https://api.unstoppableswap.net"
+      // TODO: Replace with a valid CSP. There is a bug where CSP is not being applied correctly in the production build.
+      // "csp": "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' http://localhost:1234 https://api.unstoppableswap.net"
+      "dangerousDisableAssetCspModification": true
     }
   },
   "bundle": {


### PR DESCRIPTION
- Adds a Github action file that build the binaries
- Run build command before tauri build is started
- disable tauri csp rules
- disable typescript compiler check before build