### PR TITLE
fix: Format cooperative redeem reject using thiserror (#1716)

### DIFF
--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -440,7 +440,7 @@ async fn next_state(
                     );
 
                     tracing::error!(
-                        ?reason,
+                        %reason,
                         "Alice rejected our request for cooperative XMR redeem"
                     );
 
@@ -448,7 +448,7 @@ async fn next_state(
                 }
                 Err(error) => {
                     tracing::error!(
-                        ?error,
+                        %error,
                         "Failed to request cooperative XMR redeem from Alice"
                     );
 


### PR DESCRIPTION
Applies this PR to our fork:
https://github.com/comit-network/xmr-btc-swap/pull/1716